### PR TITLE
Type::GetDecayedType() implementation

### DIFF
--- a/Resources/Templates/module-file-source.mustache
+++ b/Resources/Templates/module-file-source.mustache
@@ -21,18 +21,19 @@ void meta_generated::AllocateModuleFile{{targetName}}{{moduleFileName}}(m::Refle
     ///////////////////////////////////////////////////////////////////////////
     {{#class}}
     {
+		//ID of decayed type
+        auto decayed_id = db.AllocateType( "{{& displayName}}" );
         { // Base Type
-            auto id = db.AllocateType( "{{& displayName}}" );
-            auto &type = db.types[ id ];
+            auto &type = db.types[ decayed_id ];
 
-            m::TypeInfo<{{& qualifiedName}}>::Register( id, type, true );
+            m::TypeInfo<{{& qualifiedName}}>::Register( decayed_id, type, true, decayed_id );
         }
         {{#ptrTypeEnabled}}
         { // Pointer Type
             auto id = db.AllocateType( "{{& displayName}}*" );
             auto &type = db.types[ id ];
 
-            m::TypeInfo<{{& qualifiedName}}*>::Register( id, type, false );
+            m::TypeInfo<{{& qualifiedName}}*>::Register( id, type, false, decayed_id );
         }
         {{/ptrTypeEnabled}}
         {{#constPtrTypeEnabled}}
@@ -40,7 +41,7 @@ void meta_generated::AllocateModuleFile{{targetName}}{{moduleFileName}}(m::Refle
             auto id = db.AllocateType( "const {{& displayName}}*" );
             auto &type = db.types[ id ];
 
-            m::TypeInfo<const {{& qualifiedName}}*>::Register( id, type, false );
+            m::TypeInfo<const {{& qualifiedName}}*>::Register( id, type, false, decayed_id );
         }
         {{/constPtrTypeEnabled}}
     }
@@ -61,7 +62,7 @@ void meta_generated::AllocateModuleFile{{targetName}}{{moduleFileName}}(m::Refle
             auto id = db.AllocateType( "{{& displayName}}*" );
             auto &type = db.types[ id ];
 
-            m::TypeInfo<{{& qualifiedName}}*>::Register( id, type, false );
+            m::TypeInfo<{{& qualifiedName}}*>::Register( id, type, true );
         }
         {{/ptrTypeEnabled}}
         {{#constPtrTypeEnabled}}

--- a/Resources/Templates/module-source.mustache
+++ b/Resources/Templates/module-source.mustache
@@ -26,18 +26,19 @@ meta_generated::Module{{targetName}}::Module{{targetName}}(m::ReflectionDatabase
     ///////////////////////////////////////////////////////////////////////////
     {{#external}}
     {
-        { // Base Type
-            auto id = db.AllocateType( "{{& displayName}}" );
-            auto &type = db.types[ id ];
+            auto decayed_id = db.AllocateType( "{{& displayName}}" );
 
-            m::TypeInfo<{{& qualifiedName}}>::Register( id, type, true );
+		{ // Base Type
+            auto &type = db.types[ decayed_id ];
+
+            m::TypeInfo<{{& qualifiedName}}>::Register( decayed_id, type, true, decayed_id );
         }
         {{#ptrTypeEnabled}}
         { // Pointer Type
             auto id = db.AllocateType( "{{& displayName}}*" );
             auto &type = db.types[ id ];
 
-            m::TypeInfo<{{& qualifiedName}}*>::Register( id, type, false );
+            m::TypeInfo<{{& qualifiedName}}*>::Register( id, type, false, decayed_id );
         }
         {{/ptrTypeEnabled}}
         {{#constPtrTypeEnabled}}
@@ -45,7 +46,7 @@ meta_generated::Module{{targetName}}::Module{{targetName}}(m::ReflectionDatabase
             auto id = db.AllocateType( "const {{& displayName}}*" );
             auto &type = db.types[ id ];
 
-            m::TypeInfo<const {{& qualifiedName}}*>::Register( id, type, false );
+            m::TypeInfo<const {{& qualifiedName}}*>::Register( id, type, false, decayed_id );
         }
         {{/constPtrTypeEnabled}}
     }

--- a/Source/Runtime/Impl/TypeInfo.hpp
+++ b/Source/Runtime/Impl/TypeInfo.hpp
@@ -27,10 +27,11 @@ namespace ursine
         bool TypeInfo<T>::Defined = false;
 
         template<typename T>
-        void TypeInfo<T>::Register(
-            TypeID id, 
-            TypeData &data, 
-            bool beingDefined
+		void TypeInfo<T>::Register(
+			TypeID id,
+			TypeData &data,
+			bool beingDefined,
+			TypeID DecayedTypeID
         )
         {
             // already defined
@@ -54,6 +55,9 @@ namespace ursine
 
                 applyTrivialAttributes( data );
             }
+			//For non pointer type id is passed to DecayedTypeID
+			data.DecayedTypeID = DecayedTypeID;
+
         }
 
         template<typename T>

--- a/Source/Runtime/ReflectionDatabase.cpp
+++ b/Source/Runtime/ReflectionDatabase.cpp
@@ -10,18 +10,18 @@
 
 #include "Type.h"
 
-#define REGISTER_NATIVE_TYPE(type)                    \
+#define REGISTER_NATIVE_TYPE(type, decayed_type)      \
     {                                                 \
         auto id = AllocateType( #type );              \
         auto &handle = types[ id ];                   \
-                                                      \
-        TypeInfo<type>::Register( id, handle, true ); \
+        auto &decayed_handle = typeidof(decayed_type);         \
+        TypeInfo<type>::Register( id, handle, true, decayed_handle ); \
     }                                                 \
 
 #define REGISTER_NATIVE_TYPE_VARIANTS(type) \
-    REGISTER_NATIVE_TYPE( type )            \
-    REGISTER_NATIVE_TYPE( type* )           \
-    REGISTER_NATIVE_TYPE( const type* )     \
+    REGISTER_NATIVE_TYPE( type, type )            \
+    REGISTER_NATIVE_TYPE( type*, type )           \
+    REGISTER_NATIVE_TYPE( const type*, type )     \
 
 #define REGISTER_NATIVE_TYPE_VARIANTS_W_ARRAY(type)         \
     REGISTER_NATIVE_TYPE_VARIANTS( type )                   \

--- a/Source/Runtime/TypeData.h
+++ b/Source/Runtime/TypeData.h
@@ -42,7 +42,9 @@ namespace ursine
             // enum type
 
             Enum enumeration;
-
+			
+			//DecayedTypeID
+			TypeID DecayedTypeID;
             // class type
 
             Type::Set baseClasses;

--- a/Source/Runtime/TypeInfo.h
+++ b/Source/Runtime/TypeInfo.h
@@ -33,7 +33,7 @@ namespace ursine
         {
             static bool Defined;
 
-            static void Register(TypeID id, TypeData &data, bool beingDefined);
+            static void Register(TypeID id, TypeData &data, bool beingDefined, TypeID DecayedTypeID);
 
         private:
             template<typename U = T>


### PR DESCRIPTION
Implemented Type::GetDecayedType() by adding 4th parameter to TypeInfo::Register<T> function